### PR TITLE
fix debian/contol guh architecture

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends: debhelper (>= 9.0.0),
 Standards-Version: 3.9.5
 
 Package: guh
-Architecture: all
+Architecture: any
 Section: misc
 Depends: guh (= ${binary:Version}),
   guh-plugins (= ${binary:Version}),


### PR DESCRIPTION
guh package from all -> any
otherwise the guh meta package will be in each repository, even if plugins, libguh etc. are not available. 