### PR TITLE
make writable states more clear in plugin json

### DIFF
--- a/libguh/plugin/deviceplugin.h
+++ b/libguh/plugin/deviceplugin.h
@@ -116,6 +116,7 @@ private:
     QStringList verifyFields(const QStringList &fields, const QJsonObject &value) const;
 
     Types::Unit unitStringToUnit(const QString &unitString) const;
+    Types::InputType inputTypeStringToInputType(const QString &inputType) const;
 
     DeviceManager *m_deviceManager;
 

--- a/plugins/deviceplugins/boblight/devicepluginboblight.cpp
+++ b/plugins/deviceplugins/boblight/devicepluginboblight.cpp
@@ -40,7 +40,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/boblight/devicepluginboblight.json

--- a/plugins/deviceplugins/boblight/devicepluginboblight.json
+++ b/plugins/deviceplugins/boblight/devicepluginboblight.json
@@ -18,7 +18,7 @@
                             "name": "color",
                             "type": "QColor",
                             "defaultValue": "#000000",
-                            "writable": true
+                            "writable": {}
                         }
                     ]
                 }

--- a/plugins/deviceplugins/conrad/devicepluginconrad.cpp
+++ b/plugins/deviceplugins/conrad/devicepluginconrad.cpp
@@ -39,7 +39,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/conrad/devicepluginconrad.json

--- a/plugins/deviceplugins/datetime/deviceplugindatetime.cpp
+++ b/plugins/deviceplugins/datetime/deviceplugindatetime.cpp
@@ -71,7 +71,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/datetime/deviceplugindatetime.json

--- a/plugins/deviceplugins/elro/devicepluginelro.cpp
+++ b/plugins/deviceplugins/elro/devicepluginelro.cpp
@@ -38,7 +38,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/elro/devicepluginelro.json

--- a/plugins/deviceplugins/eq-3/deviceplugineq-3.cpp
+++ b/plugins/deviceplugins/eq-3/deviceplugineq-3.cpp
@@ -59,7 +59,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/eq-3/deviceplugineq-3.json

--- a/plugins/deviceplugins/eq-3/deviceplugineq-3.json
+++ b/plugins/deviceplugins/eq-3/deviceplugineq-3.json
@@ -210,7 +210,7 @@
                             "type": "double",
                             "unit": "DegreeCelsius",
                             "defaultValue": 0,
-                            "writable": true
+                            "writable": {}
 
                         },
                         {
@@ -373,7 +373,7 @@
                             "unit": "DegreeCelsius",
                             "type": "double",
                             "defaultValue": 0,
-                            "writable": true
+                            "writable": {}
                         },
                         {
                             "id": "576da571-9a65-478f-96bf-19256c8b9ece",

--- a/plugins/deviceplugins/genericelements/deviceplugingenericelements.cpp
+++ b/plugins/deviceplugins/genericelements/deviceplugingenericelements.cpp
@@ -49,7 +49,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/genericelements/deviceplugingenericelements.json

--- a/plugins/deviceplugins/genericelements/deviceplugingenericelements.json
+++ b/plugins/deviceplugins/genericelements/deviceplugingenericelements.json
@@ -25,7 +25,7 @@
                             "name": "state",
                             "type": "bool",
                             "defaultValue": false,
-                            "writable": true
+                            "writable": {}
                         }
                     ]
                 },

--- a/plugins/deviceplugins/intertechno/devicepluginintertechno.cpp
+++ b/plugins/deviceplugins/intertechno/devicepluginintertechno.cpp
@@ -38,7 +38,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/intertechno/devicepluginintertechno.json

--- a/plugins/deviceplugins/leynew/devicepluginleynew.cpp
+++ b/plugins/deviceplugins/leynew/devicepluginleynew.cpp
@@ -44,7 +44,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/leynew/devicepluginleynew.json

--- a/plugins/deviceplugins/lgsmarttv/devicepluginlgsmarttv.cpp
+++ b/plugins/deviceplugins/lgsmarttv/devicepluginlgsmarttv.cpp
@@ -38,7 +38,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/lgsmarttv/devicepluginlgsmarttv.json

--- a/plugins/deviceplugins/lircd/devicepluginlircd.cpp
+++ b/plugins/deviceplugins/lircd/devicepluginlircd.cpp
@@ -40,7 +40,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/lircd/devicepluginlircd.json

--- a/plugins/deviceplugins/mailnotification/devicepluginmailnotification.cpp
+++ b/plugins/deviceplugins/mailnotification/devicepluginmailnotification.cpp
@@ -56,7 +56,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/mailnotification/devicepluginmailnotification.json

--- a/plugins/deviceplugins/openweathermap/devicepluginopenweathermap.cpp
+++ b/plugins/deviceplugins/openweathermap/devicepluginopenweathermap.cpp
@@ -44,7 +44,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/openweathermap/devicepluginopenweathermap.json

--- a/plugins/deviceplugins/philipshue/devicepluginphilipshue.cpp
+++ b/plugins/deviceplugins/philipshue/devicepluginphilipshue.cpp
@@ -39,7 +39,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/philipshue/devicepluginphilipshue.json

--- a/plugins/deviceplugins/philipshue/devicepluginphilipshue.json
+++ b/plugins/deviceplugins/philipshue/devicepluginphilipshue.json
@@ -109,7 +109,7 @@
                             "name": "power",
                             "type": "bool",
                             "defaultValue": false,
-                            "writable": true
+                            "writable": {}
                         },
                         {
                             "id": "c0f4206f-f219-4f06-93c4-4ca515a56f79",
@@ -117,10 +117,11 @@
                             "name": "color temperature",
                             "type": "int",
                             "unit": "Mired",
-                            "writable": true,
                             "defaultValue": 170,
-                            "minValue": 154,
-                            "maxValue": 500
+                            "writable": {
+                                "minValue": 154,
+                                "maxValue": 500
+                            }
                         },
                         {
                             "id": "d25423e7-b924-4b20-80b6-77eecc65d089",
@@ -128,7 +129,7 @@
                             "name": "color",
                             "type": "QColor",
                             "defaultValue": "#000000",
-                            "writable": true
+                            "writable": {}
 
                         },
                         {
@@ -137,22 +138,25 @@
                             "name": "brightness",
                             "type": "int",
                             "unit": "Percentage",
-                            "writable": true,
-                            "minValue": 0,
-                            "maxValue": 100,
-                            "defaultValue": 0
+                            "defaultValue": 0,
+                            "writable": {
+                                "minValue": 0,
+                                "maxValue": 100
+                            }
                         },
                         {
                             "id": "0b7cdd8d-4db8-4183-abe2-f3c01d1c9afc",
                             "idName": "hueEffect",
                             "name": "effect",
                             "type": "QString",
-                            "writable": true,
                             "defaultValue": "none",
-                            "allowedValues": [
-                                "none",
-                                "color loop"
-                            ]
+                            "writable": {
+                                "allowedValues": [
+                                    "none",
+                                    "color loop"
+                                ]
+                            }
+
                         }
                     ],
                     "actionTypes": [

--- a/plugins/deviceplugins/tune/deviceplugintune.json
+++ b/plugins/deviceplugins/tune/deviceplugintune.json
@@ -53,7 +53,7 @@
                             "name": "active",
                             "type": "bool",
                             "defaultValue": false,
-                            "writable": true
+                            "writable": {}
                         },
                         {
                             "id": "cb8a89c2-dc12-4965-b047-57896058b421",
@@ -61,10 +61,11 @@
                             "name": "value",
                             "type": "int",
                             "unit": "Percentage",
-                            "minValue": 0,
-                            "maxValue": 100,
                             "defaultValue": 0,
-                            "writable": true
+                            "writable": {
+                                "minValue": 0,
+                                "maxValue": 100
+                            }
                         }
                     ]
                 },
@@ -121,7 +122,7 @@
                             "name": "power",
                             "type": "bool",
                             "defaultValue": 0,
-                            "writable": true
+                            "writable": {}
                         },
                         {
                             "id": "677cd9ec-c264-47ee-9d2e-d3662237792c",
@@ -129,10 +130,11 @@
                             "name": "brightness",
                             "type": "int",
                             "unit": "Percentage",
-                            "minValue": 0,
-                            "maxValue": 100,
                             "defaultValue": 0,
-                            "writable": true
+                            "writable": {
+                                "minValue": 0,
+                                "maxValue": 100
+                            }
                         }
                     ]
                 }

--- a/plugins/deviceplugins/udpcommander/devicepluginudpcommander.cpp
+++ b/plugins/deviceplugins/udpcommander/devicepluginudpcommander.cpp
@@ -56,7 +56,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/udpcommander/devicepluginudpcommander.json

--- a/plugins/deviceplugins/unitec/devicepluginunitec.cpp
+++ b/plugins/deviceplugins/unitec/devicepluginunitec.cpp
@@ -44,7 +44,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/unitec/devicepluginunitec.json

--- a/plugins/deviceplugins/wakeonlan/devicepluginwakeonlan.cpp
+++ b/plugins/deviceplugins/wakeonlan/devicepluginwakeonlan.cpp
@@ -41,7 +41,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/wakeonlan/devicepluginwakeonlan.json

--- a/plugins/deviceplugins/wemo/devicepluginwemo.cpp
+++ b/plugins/deviceplugins/wemo/devicepluginwemo.cpp
@@ -42,7 +42,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/wemo/devicepluginwemo.json

--- a/plugins/deviceplugins/wemo/devicepluginwemo.json
+++ b/plugins/deviceplugins/wemo/devicepluginwemo.json
@@ -39,7 +39,7 @@
                             "name": "power",
                             "type": "bool",
                             "defaultValue": false,
-                            "writable": true
+                            "writable": {}
 
                         },
                         {

--- a/plugins/deviceplugins/wifidetector/devicepluginwifidetector.cpp
+++ b/plugins/deviceplugins/wifidetector/devicepluginwifidetector.cpp
@@ -40,7 +40,7 @@
     The \l{DeviceClass::SetupMethod}{setupMethod} describes the setup method of the \l{Device}.
     The detailed implementation of each \l{DeviceClass} can be found in the source code.
 
-    \note If a \l{StateType} has the parameter \tt{"writable": true}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
+    \note If a \l{StateType} has the parameter \tt{"writable": {...}}, an \l{ActionType} with the same uuid and \l{ParamType}{ParamTypes}
     will be created automatically.
 
     \quotefile plugins/deviceplugins/wifidetector/devicepluginwifidetector.json

--- a/plugins/generateplugininfo.py
+++ b/plugins/generateplugininfo.py
@@ -9,99 +9,98 @@ outputfile = open(sys.argv[2], "w")
 variableNames = []
 
 try:
-	pluginMap = json.loads(inputFile.read())
-	
+    pluginMap = json.loads(inputFile.read())
+    
 except ValueError as e:
-	print " --> Error loading input file \"%s\"" % (sys.argv[1])
-	print "     %s" % (e)
-	exit -1
+    print " --> Error loading input file \"%s\"" % (sys.argv[1])
+    print "     %s" % (e)
+    exit -1
 
 
 def out(line):
-	outputfile.write("%s\n" % line)
+    outputfile.write("%s\n" % line)
 
 def extractVendors(pluginMap):
-	for vendor in pluginMap['vendors']:
-		try:
-			out("VendorId %sVendorId = VendorId(\"%s\");" % pluginMap["idName"], pluginMap["id"])
-		except:
-			pass
-		extractDeviceClasses(vendor)
+    for vendor in pluginMap['vendors']:
+        try:
+            out("VendorId %sVendorId = VendorId(\"%s\");" % pluginMap["idName"], pluginMap["id"])
+        except:
+            pass
+        extractDeviceClasses(vendor)
 
 
 def extractDeviceClasses(vendorMap):
-	for deviceClass in vendorMap["deviceClasses"]:
-		print("have deviceclass %s" % deviceClass["deviceClassId"])
-		try:
-			variableName = "%sDeviceClassId" % (deviceClass["idName"]) 
-			if not variableName in variableNames:
-				variableNames.append(variableName)
-				out("DeviceClassId %s = DeviceClassId(\"%s\");" % (variableName, deviceClass["deviceClassId"]))
-			else:
-				print("duplicated variable name \"%s\" for DeviceClassId %s -> skipping") % (variableName, deviceClass["deviceClassId"])
-		except:
-			pass
-		extractActionTypes(deviceClass)
-		extractStateTypes(deviceClass)
-		extractEventTypes(deviceClass)
+    for deviceClass in vendorMap["deviceClasses"]:
+        print("have deviceclass %s" % deviceClass["deviceClassId"])
+        try:
+            variableName = "%sDeviceClassId" % (deviceClass["idName"]) 
+            if not variableName in variableNames:
+                variableNames.append(variableName)
+                out("DeviceClassId %s = DeviceClassId(\"%s\");" % (variableName, deviceClass["deviceClassId"]))
+            else:
+                print("duplicated variable name \"%s\" for DeviceClassId %s -> skipping") % (variableName, deviceClass["deviceClassId"])
+        except:
+            pass
+        extractActionTypes(deviceClass)
+        extractStateTypes(deviceClass)
+        extractEventTypes(deviceClass)
 
 
 def extractStateTypes(deviceClassMap):
-	try:
-		for stateType in deviceClassMap["stateTypes"]:
-			try:
-				variableName = "%sStateTypeId" % (stateType["idName"])
-				if not variableName in variableNames:
-					variableNames.append(variableName)
-					out("StateTypeId %s = StateTypeId(\"%s\");" % (variableName, stateType["id"]))
-				else:
-					print("duplicated variable name \"%s\" for StateTypeId %s -> skipping") % (variableName, stateType["id"])
-				# create ActionTypeId if the state is writable
-				if 'writable' in stateType:
-					if stateType['writable'] == True:
-						print("create ActionTypeId for StateType %s" % stateType["id"])
-						vName = "%sActionTypeId" % (stateType["idName"]) 
-						if not vName in variableNames:
-							variableNames.append(vName)
-							out("ActionTypeId %s = ActionTypeId(\"%s\");" % (vName, stateType["id"]))
-						else:
-							print("duplicated variable name \"%s\" for ActionTypeId %s -> skipping") % (variableName, stateType["id"])
-			except:
-				pass
-	except:
-		pass
+    try:
+        for stateType in deviceClassMap["stateTypes"]:
+            try:
+                variableName = "%sStateTypeId" % (stateType["idName"])
+                if not variableName in variableNames:
+                    variableNames.append(variableName)
+                    out("StateTypeId %s = StateTypeId(\"%s\");" % (variableName, stateType["id"]))
+                else:
+                    print("duplicated variable name \"%s\" for StateTypeId %s -> skipping") % (variableName, stateType["id"])
+                # create ActionTypeId if the state is writable
+                if 'writable' in stateType:
+                    print("create ActionTypeId for StateType %s" % stateType["id"])
+                    vName = "%sActionTypeId" % (stateType["idName"]) 
+                    if not vName in variableNames:
+                        variableNames.append(vName)
+                        out("ActionTypeId %s = ActionTypeId(\"%s\");" % (vName, stateType["id"]))
+                    else:
+                        print("duplicated variable name \"%s\" for ActionTypeId %s -> skipping") % (variableName, stateType["id"])
+            except:
+                pass
+    except:
+        pass
 
 
 def extractActionTypes(deviceClassMap):
-	try:
-		for actionType in deviceClassMap["actionTypes"]:
-			try:
-				variableName = "%sActionTypeId" % (actionType["idName"])
-				if not variableName in variableNames:
-					variableNames.append(variableName)
-					out("ActionTypeId %s = ActionTypeId(\"%s\");" % (variableName, actionType["id"]))
-				else:
-					print("duplicated variable name \"%s\" for ActionTypeId %s -> skipping") % (variableName, actionType["id"])
-			except:
-				pass
-	except:
-		pass
+    try:
+        for actionType in deviceClassMap["actionTypes"]:
+            try:
+                variableName = "%sActionTypeId" % (actionType["idName"])
+                if not variableName in variableNames:
+                    variableNames.append(variableName)
+                    out("ActionTypeId %s = ActionTypeId(\"%s\");" % (variableName, actionType["id"]))
+                else:
+                    print("duplicated variable name \"%s\" for ActionTypeId %s -> skipping") % (variableName, actionType["id"])
+            except:
+                pass
+    except:
+        pass
 
 
 def extractEventTypes(deviceClassMap):
-	try:
-		for eventType in deviceClassMap["eventTypes"]:
-			try:
-				variableName = "%sEventTypeId" % (eventType["idName"])
-				if not variableName in variableNames:
-					variableNames.append(variableName)
-					out("EventTypeId %s = EventTypeId(\"%s\");" % (variableName, eventType["id"]))
-				else:
-					print("duplicated variable name \"%s\" for EventTypeId %s -> skipping") % (variableName, eventType["id"])
-			except:
-				pass
-	except:
-		pass
+    try:
+        for eventType in deviceClassMap["eventTypes"]:
+            try:
+                variableName = "%sEventTypeId" % (eventType["idName"])
+                if not variableName in variableNames:
+                    variableNames.append(variableName)
+                    out("EventTypeId %s = EventTypeId(\"%s\");" % (variableName, eventType["id"]))
+                else:
+                    print("duplicated variable name \"%s\" for EventTypeId %s -> skipping") % (variableName, eventType["id"])
+            except:
+                pass
+    except:
+        pass
 
 
 print " --> generate plugininfo.h"


### PR DESCRIPTION
example: if a state is writable, a developer can define it by adding:

    ...state definition...
    writable: {
        "minValue": 0,
        "maxValue": 100,
        "InputType": "..."
     }

or

    ...state definition...
    writable: {
        "allowedValues": [
            "A",
            "B"
     }
