### PR TITLE
add missing include to coap header file

### DIFF
--- a/libguh/coap/coappdublock.cpp
+++ b/libguh/coap/coappdublock.cpp
@@ -19,6 +19,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include "coappdublock.h"
+#include <math.h>
 
 CoapPduBlock::CoapPduBlock()
 {


### PR DESCRIPTION
guh does not compile otherwise (pow function not declared)