### PR TITLE
fix time events for rules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Homepage: https://guh.io
 Vcs-Git: https://github.com/guh/guh.git
 Build-Depends: debhelper (>= 9.0.0),
                dpkg-dev (>= 1.16.1~),
-               python,
+               python:any,
                rsync,
                qtchooser,
                qt5-default,

--- a/debian/rules
+++ b/debian/rules
@@ -10,6 +10,11 @@ else
 	DEB_PARALLEL_JOBS += $(shell getconf _NPROCESSORS_ONLN)
 endif
 
+MAKE_TARGETS="all"
+ifneq (,$(filter nodocs,$(DEB_BUILD_OPTIONS)))
+	MAKE_TARGETS += " doc"
+endif 
+
 DPKG_EXPORT_BUILDFLAGS = 1
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
@@ -22,13 +27,7 @@ $(PREPROCESS_FILES:.in=): %: %.in
 
 
 override_dh_auto_build:
-	make -j$(DEB_PARALLEL_JOBS)
-	make doc
-
-
-override_dh_auto_test:
-	make test
-
+	make -j$(DEB_PARALLEL_JOBS) $(MAKE_TARGETS)
 
 override_dh_install: $(PREPROCESS_FILES:.in=)
 	dh_install --fail-missing

--- a/server/ruleengine.cpp
+++ b/server/ruleengine.cpp
@@ -122,7 +122,8 @@ namespace guhserver {
     instance available from \l{GuhCore}. This one should be used instead of creating multiple ones.
  */
 RuleEngine::RuleEngine(QObject *parent) :
-    QObject(parent)
+    QObject(parent),
+    m_lastEvaluationTime(QDateTime::currentDateTime())
 {
     GuhSettings settings(GuhSettings::SettingsRoleRules);
     qCDebug(dcRuleEngine) << "loading rules from" << settings.fileName();
@@ -396,7 +397,7 @@ QList<Rule> RuleEngine::evaluateTime(const QDateTime &dateTime)
             // check if this rule is based on calendarItems
             if (!rule.timeDescriptor().calendarItems().isEmpty()) {
                 //qCDebug(dcRuleEngine()) << "Evaluate CalendarItem against" << dateTime.toString("dd:MM:yyyy hh:mm") << "for rule" << rule.id().toString();
-                bool active = rule.timeDescriptor().evaluate(dateTime);
+                bool active = rule.timeDescriptor().evaluate(m_lastEvaluationTime, dateTime);
                 if (active) {
                     if (!m_activeRules.contains(rule.id())) {
                         qCDebug(dcRuleEngine) << "Rule" << rule.id().toString() << "active.";
@@ -418,7 +419,7 @@ QList<Rule> RuleEngine::evaluateTime(const QDateTime &dateTime)
 
             // check if this rule is based on timeEventItems
             if (!rule.timeDescriptor().timeEventItems().isEmpty()) {
-                bool valid = rule.timeDescriptor().evaluate(dateTime);
+                bool valid = rule.timeDescriptor().evaluate(m_lastEvaluationTime, dateTime);
                 if (valid) {
                     rules.append(rule);
                 }
@@ -426,6 +427,7 @@ QList<Rule> RuleEngine::evaluateTime(const QDateTime &dateTime)
         }
     }
 
+    m_lastEvaluationTime = QDateTime::currentDateTime();
     return rules;
 }
 

--- a/server/ruleengine.cpp
+++ b/server/ruleengine.cpp
@@ -122,8 +122,7 @@ namespace guhserver {
     instance available from \l{GuhCore}. This one should be used instead of creating multiple ones.
  */
 RuleEngine::RuleEngine(QObject *parent) :
-    QObject(parent),
-    m_lastEvaluationTime(GuhCore::instance()->timeManager()->currentDateTime())
+    QObject(parent)
 {
     GuhSettings settings(GuhSettings::SettingsRoleRules);
     qCDebug(dcRuleEngine) << "loading rules from" << settings.fileName();
@@ -384,6 +383,11 @@ QList<Rule> RuleEngine::evaluateEvent(const Event &event)
 */
 QList<Rule> RuleEngine::evaluateTime(const QDateTime &dateTime)
 {
+    if (!m_lastEvaluationTime.isValid()) {
+        m_lastEvaluationTime = dateTime;
+        m_lastEvaluationTime.addSecs(-1);
+    }
+
     QList<Rule> rules;
 
     foreach (const Rule &r, m_rules.values()) {
@@ -427,7 +431,7 @@ QList<Rule> RuleEngine::evaluateTime(const QDateTime &dateTime)
         }
     }
 
-    m_lastEvaluationTime = GuhCore::instance()->timeManager()->currentDateTime();
+    m_lastEvaluationTime = dateTime;
     return rules;
 }
 

--- a/server/ruleengine.cpp
+++ b/server/ruleengine.cpp
@@ -123,7 +123,7 @@ namespace guhserver {
  */
 RuleEngine::RuleEngine(QObject *parent) :
     QObject(parent),
-    m_lastEvaluationTime(QDateTime::currentDateTime())
+    m_lastEvaluationTime(GuhCore::instance()->timeManager()->currentDateTime())
 {
     GuhSettings settings(GuhSettings::SettingsRoleRules);
     qCDebug(dcRuleEngine) << "loading rules from" << settings.fileName();
@@ -427,7 +427,7 @@ QList<Rule> RuleEngine::evaluateTime(const QDateTime &dateTime)
         }
     }
 
-    m_lastEvaluationTime = QDateTime::currentDateTime();
+    m_lastEvaluationTime = GuhCore::instance()->timeManager()->currentDateTime();
     return rules;
 }
 

--- a/server/ruleengine.h
+++ b/server/ruleengine.h
@@ -112,6 +112,8 @@ private:
     QList<RuleId> m_ruleIds; // Keeping a list of RuleIds to keep sorting order...
     QHash<RuleId, Rule> m_rules; // ...but use a Hash for faster finding
     QList<RuleId> m_activeRules;
+
+    QDateTime m_lastEvaluationTime;
 };
 
 }

--- a/server/time/timedescriptor.cpp
+++ b/server/time/timedescriptor.cpp
@@ -82,7 +82,7 @@ bool TimeDescriptor::isEmpty() const
     valid if the \l{TimeEventItem}{TimeEventItems} or \l{CalendarItem}{CalendarItems} match
     the given \a dateTime.
 */
-bool TimeDescriptor::evaluate(const QDateTime &dateTime) const
+bool TimeDescriptor::evaluate(const QDateTime &lastEvaluationTime, const QDateTime &dateTime) const
 {
     // If there are calendarItems (always OR connected)
     if (!m_calendarItems.isEmpty()) {
@@ -96,7 +96,7 @@ bool TimeDescriptor::evaluate(const QDateTime &dateTime) const
     // If there are timeEventItems (always OR connected)
     if (!m_timeEventItems.isEmpty()) {
         foreach (const TimeEventItem &timeEventItem, m_timeEventItems) {
-            if (timeEventItem.evaluate(dateTime)) {
+            if (timeEventItem.evaluate(lastEvaluationTime, dateTime)) {
                 return true;
             }
         }

--- a/server/time/timedescriptor.h
+++ b/server/time/timedescriptor.h
@@ -41,7 +41,7 @@ public:
     bool isValid() const;
     bool isEmpty() const;
 
-    bool evaluate(const QDateTime &dateTime) const;
+    bool evaluate(const QDateTime &lastEvaluationTime, const QDateTime &dateTime) const;
 
 //    void dumpToSettings(GuhSettings &settings, const QString &groupName) const;
 //    static TimeDescriptor loadFromSettings(GuhSettings &settings, const QString &groupPrefix);

--- a/server/time/timeeventitem.h
+++ b/server/time/timeeventitem.h
@@ -45,7 +45,7 @@ public:
 
     bool isValid() const;
 
-    bool evaluate(const QDateTime &dateTime) const;
+    bool evaluate(const QDateTime &lastEvaluationTime, const QDateTime &dateTime) const;
 
 private:
     QDateTime m_dateTime;


### PR DESCRIPTION
old code would compare QTime == QTime() every second which might not trigger
if e.g. milliseconds don't match. New code checks the interval between the
last check and the current one.