### PR TITLE
fix avahi service browser destruction

### DIFF
--- a/libguh/network/avahi/qtavahiservicebrowser_p.h
+++ b/libguh/network/avahi/qtavahiservicebrowser_p.h
@@ -35,6 +35,7 @@ class LIBGUH_EXPORT QtAvahiServiceBrowserPrivate
 {
 public:
     QtAvahiServiceBrowserPrivate(QtAvahiClient *client);
+    ~QtAvahiServiceBrowserPrivate();
 
     // Callback members
     static void callbackServiceTypeBrowser(AvahiServiceTypeBrowser *browser,
@@ -76,6 +77,7 @@ public:
     QtAvahiClient *client;
     AvahiServiceTypeBrowser *serviceTypeBrowser;
     QHash<QString, AvahiServiceBrowser *> serviceBrowserTable;
+    QList<AvahiServiceResolver *> m_serviceResolvers;
 };
 
 #endif // QTAVAHISERVICEBROWSERPRIVATE_H


### PR DESCRIPTION
without keeping track of the avahi service resolvers and
destroying them when the parent object goes away, callbacks
might be called after after the destruction and passing
an invalid userdata pointer.