### PR TITLE
Add default webinterface path for snap environment

### DIFF
--- a/libguh-core/guhconfiguration.cpp
+++ b/libguh-core/guhconfiguration.cpp
@@ -99,7 +99,7 @@ GuhConfiguration::GuhConfiguration(QObject *parent) :
         insecureConfig.port = 80;
         insecureConfig.sslEnabled = false;
         insecureConfig.authenticationEnabled = false;
-        insecureConfig.publicFolder = "/usr/share/guh-webinterface/public/";
+        insecureConfig.publicFolder = defaultWebserverPublicFolderPath();
         m_webServerConfigs[insecureConfig.id] = insecureConfig;
         storeWebServerConfig(insecureConfig);
 
@@ -109,7 +109,7 @@ GuhConfiguration::GuhConfiguration(QObject *parent) :
         secureConfig.port = 443;
         secureConfig.sslEnabled = true;
         secureConfig.authenticationEnabled = false;
-        secureConfig.publicFolder = "/usr/share/guh-webinterface/public/";
+        secureConfig.publicFolder = defaultWebserverPublicFolderPath();
         m_webServerConfigs[secureConfig.id] = secureConfig;
         storeWebServerConfig(secureConfig);
     }
@@ -324,6 +324,18 @@ void GuhConfiguration::setServerUuid(const QUuid &uuid)
     settings.beginGroup("guhd");
     settings.setValue("uuid", uuid);
     settings.endGroup();
+}
+
+QString GuhConfiguration::defaultWebserverPublicFolderPath() const
+{
+    QString publicFolderPath;
+    if (!qgetenv("SNAP").isEmpty()) {
+        // FIXME: one could point to sensible data by changing the SNAP env to i.e /etc
+        publicFolderPath = QString(qgetenv("SNAP")) + "/guh-webinterface";
+    } else {
+        publicFolderPath = "/usr/share/guh-webinterface/public/";
+    }
+    return publicFolderPath;
 }
 
 void GuhConfiguration::storeServerConfig(const QString &group, const ServerConfiguration &config)

--- a/libguh-core/guhconfiguration.h
+++ b/libguh-core/guhconfiguration.h
@@ -117,6 +117,8 @@ private:
     void setServerUuid(const QUuid &uuid);
     void setWebServerPublicFolder(const QString & path);
 
+    QString defaultWebserverPublicFolderPath() const;
+
     void storeServerConfig(const QString &group, const ServerConfiguration &config);
     ServerConfiguration readServerConfig(const QString &group, const QString &id);
     void deleteServerConfig(const QString &group, const QString &id);

--- a/libguh-core/webserver.cpp
+++ b/libguh-core/webserver.cpp
@@ -140,6 +140,18 @@ void WebServer::sendHttpReply(HttpReply *reply)
     socket->write(reply->data());
 }
 
+QString WebServer::defaultPublicFolderPath() const
+{
+    QString publicFolderPath;
+    if (!qgetenv("SNAP").isEmpty()) {
+        publicFolderPath = QString(qgetenv("SNAP")) + "/guh-webinterface";
+    } else {
+        publicFolderPath =
+    }
+
+
+}
+
 bool WebServer::verifyFile(QSslSocket *socket, const QString &fileName)
 {
     QFileInfo file(fileName);

--- a/libguh-core/webserver.cpp
+++ b/libguh-core/webserver.cpp
@@ -140,18 +140,6 @@ void WebServer::sendHttpReply(HttpReply *reply)
     socket->write(reply->data());
 }
 
-QString WebServer::defaultPublicFolderPath() const
-{
-    QString publicFolderPath;
-    if (!qgetenv("SNAP").isEmpty()) {
-        publicFolderPath = QString(qgetenv("SNAP")) + "/guh-webinterface";
-    } else {
-        publicFolderPath =
-    }
-
-
-}
-
 bool WebServer::verifyFile(QSslSocket *socket, const QString &fileName)
 {
     QFileInfo file(fileName);

--- a/libguh/guhsettings.cpp
+++ b/libguh/guhsettings.cpp
@@ -143,7 +143,7 @@ QString GuhSettings::logPath()
     return logPath;
 }
 
-/*! Returns the path to the folder where the GuhSettings will be saved. */
+/*! Returns the path to the folder where the GuhSettings will be saved i.e. \tt{/etc/guh}. */
 QString GuhSettings::settingsPath()
 {
     QString path;
@@ -154,7 +154,7 @@ QString GuhSettings::settingsPath()
     } else if (organisationName == "guh-test") {
         path = "/tmp/" + organisationName;
     } else if (GuhSettings::isRoot()) {
-        path = "/etc/guh/";
+        path = "/etc/guh";
     } else {
         path = QDir::homePath() + "/.config/" + organisationName;
     }
@@ -171,6 +171,7 @@ QString GuhSettings::translationsPath()
     }
 }
 
+/*! Returns the default system sorage path i.e. \tt{/var/lib/guh}. */
 QString GuhSettings::storagePath()
 {
     QString path;
@@ -178,11 +179,11 @@ QString GuhSettings::storagePath()
     if (!qgetenv("SNAP").isEmpty()) {
         path = QString(qgetenv("SNAP_DATA"));
     } else if (organisationName == "guh-test") {
-        path = "/tmp/" + organisationName + "/";
+        path = "/tmp/" + organisationName;
     } else if (GuhSettings::isRoot()) {
-        path = "/var/lib/" + organisationName + "/";
+        path = "/var/lib/" + organisationName;
     } else {
-        path = QDir::homePath() + "/.local/share/" + organisationName + "/";
+        path = QDir::homePath() + "/.local/share/" + organisationName;
     }
     return path;
 }


### PR DESCRIPTION
Note: the paths from the GuhSettings should not end with `/` in order to prevent outputs like: `/var/lib/guh//certs/guhd-certificate.crt` (note the double slash). Currently this was mixed, somethimes with `/` ant the end, sometimes not. 