### PR TITLE
decrease keepalive timeout to 30 secs, now that aws billing has changed

### DIFF
--- a/libguh-core/awsconnector.cpp
+++ b/libguh-core/awsconnector.cpp
@@ -93,7 +93,7 @@ void AWSConnector::doConnect()
 
     qCDebug(dcAWS()) << "Connecting to AWS with ID:" << m_clientId << "endpoint:" << m_currentEndpoint << "Min reconnect timeout:" << m_client->GetMinReconnectBackoffTimeout().count() << "Max reconnect timeout:" << (quint32)m_client->GetMaxReconnectBackoffTimeout().count();
     m_connectingFuture = QtConcurrent::run([&]() {
-        ResponseCode rc = m_client->Connect(std::chrono::milliseconds(3000), true, mqtt::Version::MQTT_3_1_1, std::chrono::seconds(1200), Utf8String::Create(m_clientId.toStdString()), nullptr, nullptr, nullptr);
+        ResponseCode rc = m_client->Connect(std::chrono::milliseconds(10000), true, mqtt::Version::MQTT_3_1_1, std::chrono::seconds(30), Utf8String::Create(m_clientId.toStdString()), nullptr, nullptr, nullptr);
         if (rc == ResponseCode::MQTT_CONNACK_CONNECTION_ACCEPTED) {
             staticMetaObject.invokeMethod(this, "onConnected", Qt::QueuedConnection);
         } else {


### PR DESCRIPTION
Now that AWS has changed pricing to not bill keepalive messages (effective starting at 01.01.2018) let's decrease the timeout again to the smallest value that's not billed extra (30 secs).

After collecting some experience with the longer timeout we merged recently I noticed a decrease in availability in some certain circumstances (connection drop detection) which should improve greatly again with the new timeout values.